### PR TITLE
Adding a bunch of Syntaxes, UTIs, and cleaning stuff

### DIFF
--- a/Application/Info.plist
+++ b/Application/Info.plist
@@ -72,6 +72,7 @@
 				<string>org.lua.lua-source</string>
 				<string>org.microsoft.inf</string>
 				<string>org.nfo</string>
+				<string>org.n8gray.awk</string>
 				<string>org.n8gray.bat</string>
 				<string>org.n8gray.diff-script</string>
 				<string>org.n8gray.idl</string>
@@ -123,15 +124,17 @@
 				<string>public.zsh-script</string>
 				<string>tk.tcl.tcl</string>
 				<string>tk.tcl.tcl-source</string>
-				<string>dyn.ah62d4rv4ge81g22</string>
-				<string>dyn.ah62d4rv4ge81g6pq</string>
 				<string>dyn.ah62d4rv4ge8007a</string>
-				<string>dyn.ah62d4rv4ge80s6xbqv0gn</string>
-				<string>dyn.ah62d4rv4ge81g25brvuu</string>
+				<string>dyn.ah62d4rv4ge80c75p</string>
 				<string>dyn.ah62d4rv4ge80g62</string>
-				<string>dyn.ah62d4rv4ge80w5pq</string>
 				<string>dyn.ah62d4rv4ge80s52</string>
+				<string>dyn.ah62d4rv4ge80s6xbqv0gn</string>
+				<string>dyn.ah62d4rv4ge80w5pq</string>
 				<string>dyn.ah62d4rv4ge80y652</string>
+				<string>dyn.ah62d4rv4ge81g22</string>
+				<string>dyn.ah62d4rv4ge81g25brvuu</string>
+				<string>dyn.ah62d4rv4ge81g25xsq</string>
+				<string>dyn.ah62d4rv4ge81g6pq</string>
 			</array>
 			<key>NSDocumentClass</key>
 			<string>$(PRODUCT_MODULE_NAME).Document</string>
@@ -842,6 +845,24 @@
 			<key>UTTypeConformsTo</key>
 			<array>
 				<string>public.source-code</string>
+				<string>dyn.ah62d4rv4ge80c75p</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>G(AWK) Source File</string>
+			<key>UTTypeIdentifier</key>
+			<string>org.n8gray.awk</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>awk</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.source-code</string>
 			</array>
 			<key>UTTypeDescription</key>
 			<string>DOS Batch Source File</string>
@@ -1395,6 +1416,7 @@
 			<key>UTTypeConformsTo</key>
 			<array>
 				<string>public.source-code</string>
+				<string>dyn.ah62d4rv4ge81g25xsq</string>
 			</array>
 			<key>UTTypeDescription</key>
 			<string>SCSS source file</string>

--- a/Application/Info.plist
+++ b/Application/Info.plist
@@ -123,6 +123,7 @@
 				<string>public.zsh-script</string>
 				<string>tk.tcl.tcl</string>
 				<string>tk.tcl.tcl-source</string>
+				<string>dyn.ah62d4rv4ge81g22</string>
 				<string>dyn.ah62d4rv4ge81g6pq</string>
 				<string>dyn.ah62d4rv4ge8007a</string>
 				<string>dyn.ah62d4rv4ge80s6xbqv0gn</string>
@@ -1216,6 +1217,7 @@
 			<array>
 				<string>public.source-code</string>
 				<string>dyn.ah62d4rv4ge81g22</string>
+				<string>dyn.ah62d4rv4ge81g25brvuu</string>
 			</array>
 			<key>UTTypeDescription</key>
 			<string>Scala Source Code</string>

--- a/Application/Info.plist
+++ b/Application/Info.plist
@@ -99,6 +99,7 @@
 				<string>org.tug.tex</string>
 				<string>org.vim.vim-script</string>
 				<string>org.xul.source</string>
+				<string>public.bash-script</string>
 				<string>public.css</string>
 				<string>public.c-source</string>
 				<string>public.c-plus-plus-source</string>
@@ -119,6 +120,7 @@
 				<string>public.text</string>
 				<string>public.xml</string>
 				<string>public.yaml</string>
+				<string>public.zsh-script</string>
 				<string>tk.tcl.tcl</string>
 				<string>tk.tcl.tcl-source</string>
 				<string>dyn.ah62d4rv4ge81g6pq</string>
@@ -1267,6 +1269,24 @@
 			<key>UTTypeConformsTo</key>
 			<array>
 				<string>public.source-code</string>
+				<string>public.shell-script</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Bash Script</string>
+			<key>UTTypeIdentifier</key>
+			<string>public.bash-script</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>bash</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.source-code</string>
 			</array>
 			<key>UTTypeDescription</key>
 			<string>CSS File</string>
@@ -1329,6 +1349,24 @@
 			<dict>
 				<key>public.filename-extension</key>
 				<string>text</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.source-code</string>
+				<string>public.shell-script</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Zsh Script</string>
+			<key>UTTypeIdentifier</key>
+			<string>public.zsh-script</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>zsh</string>
+				</array>
 			</dict>
 		</dict>
 		<dict>

--- a/Application/Info.plist
+++ b/Application/Info.plist
@@ -42,12 +42,14 @@
 				<string>com.sun.javafx</string>
 				<string>com.sun.java-class</string>
 				<string>com.sun.manifest</string>
+				<string>com.unknown.lhs</string>
 				<string>net.daringfireball.markdown</string>
 				<string>org.applescript.source</string>
 				<string>org.arduino.ino-source</string>
 				<string>org.arduino.source</string>
 				<string>org.asm.source</string>
 				<string>org.bash.source</string>
+				<string>org.clojure</string>
 				<string>org.codehaus.groovy-source</string>
 				<string>org.coffee.source</string>
 				<string>org.coffeescript.coffeescript</string>
@@ -90,8 +92,10 @@
 				<string>org.ocaml.ocaml-source</string>
 				<string>org.omg.ecore</string>
 				<string>org.rdf.source</string>
+				<string>org.rust-lang.source</string>
 				<string>org.sbarex.dart</string>
 				<string>org.scala.source</string>
+				<string>org.tug.lua</string>
 				<string>org.tug.tex</string>
 				<string>org.vim.vim-script</string>
 				<string>org.xul.source</string>
@@ -528,6 +532,7 @@
 				<key>public.filename-extension</key>
 				<array>
 					<string>bashrc</string>
+					<string>zshrc</string>
 				</array>
 			</dict>
 		</dict>
@@ -694,6 +699,7 @@
 			<key>UTTypeConformsTo</key>
 			<array>
 				<string>public.source-code</string>
+				<string>com.unknown.lhs</string>
 			</array>
 			<key>UTTypeDescription</key>
 			<string>Literate Haskell Source File</string>
@@ -781,6 +787,7 @@
 			<key>UTTypeConformsTo</key>
 			<array>
 				<string>public.source-code</string>
+				<string>org.tug.lua</string>
 			</array>
 			<key>UTTypeDescription</key>
 			<string>Lua Source File</string>
@@ -850,6 +857,7 @@
 			<key>UTTypeConformsTo</key>
 			<array>
 				<string>public.script</string>
+				<string>public.patch-file</string>
 			</array>
 			<key>UTTypeDescription</key>
 			<string>Diff File</string>
@@ -938,6 +946,7 @@
 			<key>UTTypeConformsTo</key>
 			<array>
 				<string>public.source-code</string>
+				<string>org.clojure</string>
 			</array>
 			<key>UTTypeDescription</key>
 			<string>Lisp Source File</string>
@@ -1167,6 +1176,24 @@
 		<dict>
 			<key>UTTypeConformsTo</key>
 			<array>
+				<string>public.source-code</string>
+				<string>dyn.ah62d4rv4ge81e62</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Rust Source File</string>
+			<key>UTTypeIdentifier</key>
+			<string>org.rust-lang.source</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>rust</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
 				<string>public.text</string>
 				<string>public.source-code</string>
 			</array>
@@ -1186,6 +1213,7 @@
 			<key>UTTypeConformsTo</key>
 			<array>
 				<string>public.source-code</string>
+				<string>dyn.ah62d4rv4ge81g22</string>
 			</array>
 			<key>UTTypeDescription</key>
 			<string>Scala Source Code</string>
@@ -1195,6 +1223,8 @@
 			<dict>
 				<key>public.filename-extension</key>
 				<array>
+					<string>sc</string>
+					<string>sbt</string>
 					<string>scala</string>
 				</array>
 			</dict>
@@ -1291,6 +1321,19 @@
 		<dict>
 			<key>UTTypeConformsTo</key>
 			<array>
+				<string>public.plain-text</string>
+			</array>
+			<key>UTTypeIdentifier</key>
+			<string>public.text</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<string>text</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
 				<string>public.source-code</string>
 			</array>
 			<key>UTTypeDescription</key>
@@ -1338,6 +1381,7 @@
 			<dict>
 				<key>public.filename-extension</key>
 				<string>xml</string>
+				<string>plist</string>
 				<key>public.mime-type</key>
 				<array>
 					<string>application/xml</string>

--- a/QLExtension/Info.plist
+++ b/QLExtension/Info.plist
@@ -89,6 +89,7 @@
 				<string>org.lua.lua-source</string>
 				<string>org.microsoft.inf</string>
 				<string>org.nfo</string>
+				<string>org.n8gray.awk</string>
 				<string>org.n8gray.bat</string>
 				<string>org.n8gray.diff-script</string>
 				<string>org.n8gray.idl</string>
@@ -116,6 +117,7 @@
 				<string>org.tug.tex</string>
 				<string>org.vim.vim-script</string>
 				<string>org.xul.source</string>
+				<string>public.bash-script</string>
 				<string>public.css</string>
 				<string>public.c-source</string>
 				<string>public.c-plus-plus-source</string>
@@ -136,16 +138,20 @@
 				<string>public.text</string>
 				<string>public.xml</string>
 				<string>public.yaml</string>
+				<string>public.zsh-script</string>
 				<string>tk.tcl.tcl</string>
 				<string>tk.tcl.tcl-source</string>
-				<string>dyn.ah62d4rv4ge81g6pq</string>
 				<string>dyn.ah62d4rv4ge8007a</string>
-				<string>dyn.ah62d4rv4ge80s6xbqv0gn</string>
-				<string>dyn.ah62d4rv4ge81g25brvuu</string>
+				<string>dyn.ah62d4rv4ge80c75p</string>
 				<string>dyn.ah62d4rv4ge80g62</string>
-				<string>dyn.ah62d4rv4ge80w5pq</string>
 				<string>dyn.ah62d4rv4ge80s52</string>
+				<string>dyn.ah62d4rv4ge80s6xbqv0gn</string>
+				<string>dyn.ah62d4rv4ge80w5pq</string>
 				<string>dyn.ah62d4rv4ge80y652</string>
+				<string>dyn.ah62d4rv4ge81g22</string>
+				<string>dyn.ah62d4rv4ge81g25brvuu</string>
+				<string>dyn.ah62d4rv4ge81g25xsq</string>
+				<string>dyn.ah62d4rv4ge81g6pq</string>
 			</array>
 			<key>QLSupportsSearchableItems</key>
 			<false/>


### PR DESCRIPTION
Hi @sbarex! Thanks for that life changing plugin.

I changed the `info.plist` in the `Application` and the `QLExtension` directories so that SyntaxHighlight detects more filetypes.

### 🚨 🚨 What changes:

#### New Syntax Supported
_(Note: Obviously, [all of these languages](https://gitlab.com/saalen/highlight/blob/master/README_LANGLIST.adoc) are supported by highlight.)_
- `.rs` (Rust) support (`org.rust-lang.source`)
- `.text` extension (`public.plain-text`)
- `.bash` and `.zsh` extension (`public.bash-script` and `public.zsh-script`)
- `.awk`

#### New UTIs
_(Note: The UTIs here correspond to the UTIs dispayed on my computer for the following extensions.)_
- `public.patch-file` as a valid UTI for `.diff` and `.patch`
- `org.clojure` as a valid UTI for `.clj` files. (Put them under the lisp files)
- `com.unknown.lhs` as a valid UTI for `.lhs` (Literate Haskell) files.
- `org.tug.lua` as a valid UTI for `.lua` files. (This happens when TexShop is installed.)
- `dyn.ah62d4rv4ge81g22` as a valid UTI for Scala files.
- `dyn.ah62d4rv4ge81g25xsq` as a valid UTI for SCSS files.

#### New File Extensions for Existing Syntaxes
- `sc` (Scala Worksheet) and `sbt` (Scala Build Tool Config) are extensions that obey the Scala syntax
- `zshrc` for Shell Scripts
- `plist` added to XML files.

#### Unifying `QLExtension/Info.plist` and `Application/Info.plist`
- Added `net.daringfireball.markdown` (md), which was missing.
- Re-established alphabetical order for `public.swift-source` and `org.coffeescript.coffeescript`
- The `dyn.XXXXX` are in alphabetical order, for those who keep track.

### 🚨 🚨 What has NOT changed
_...But may be warranted in the near future_
- `.cfg` (Python Config) files:
  - UTI:`dyn.ah62d4rv4ge80g3xh`
  - Should be linked to `public.plain-text`, or `com.microsoft.ini`
  - Note: `.cfg` is _not_ recognized by highlight as an extension natively.
- `public.data`, and `com.apple.traditional-mac-plain-text`:
  - Yes, they are not extensions.
  - But, right now, README, Makefile, dockerfiles, etc. are not recognized
  - Which is a problem for Dockerfiles, which are natively parsed by highlight.
  - In general, it might be good to display `public.data` file as `public.plain-text` if we detect that they are UTF-8. This is probably possible to implement...

And that's it! Thanks again @sbarex! :)