### PR TITLE
Add period to help argument description

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ $ /Application/Syntax\ Highlight.app/Contents/Resources/syntax_highlight_cli -h
 Usage: syntax_highlight_cli [-o <path>] <file> [..]
 
 Arguments:
- -h                              Show this help and exit
+ -h                              Show this help and exit.
  -t                              Test without save/output the result.
  -o <path>                       Save the output to <path>.
                                  If <path> is a directory a new file is created with the name of the source.

--- a/syntax_highlight_cli/main.swift
+++ b/syntax_highlight_cli/main.swift
@@ -25,7 +25,7 @@ func usage(exitCode: Int = -1) {
     print("\(name)")
     print("Usage: \(name) [-o <path>] <file> [..]")
     print("\nArguments:")
-    print(" -h                          \tShow this help and exit")
+    print(" -h                          \tShow this help and exit.")
     
     print(" -t                          \tTest without save/output the result.")
     print(" -o <path>                   \tSave the output to <path>.")


### PR DESCRIPTION
This pull request adds a trailing period to be consistent with the other argument descriptions.