### PR TITLE
Fix null characters in binary plists

### DIFF
--- a/Application/resources/settings.yaml
+++ b/Application/resources/settings.yaml
@@ -5,7 +5,7 @@ UTIs:
         
     _plist: &plist
         syntax: xml
-        preprocessor: /usr/bin/plutil -convert xml1 -o - $targetHL
+        preprocessor: /usr/bin/plutil -convert xml1 -o - $targetHL | perl -pe 's/\x00/␀/g'
 
     _xml: &xml
         syntax: xml
@@ -523,7 +523,7 @@ extensions:
         syntax: json
     _plist*: &plist
         syntax: xml
-        preprocessor: /usr/bin/plutil -convert xml1 -o - $targetHL
+        preprocessor: /usr/bin/plutil -convert xml1 -o - $targetHL | perl -pe 's/\x00/␀/g'
 
     _xml*: &xml
         syntax: xml


### PR DESCRIPTION
This prevents null characters from terminating lines when converting binary plist files to XML.

Before:
```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
    <key>nullByte</key>
    <string>text
</dict>
</plist>
```

After:
```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
    <key>nullByte</key>
    <string>text␀more</string>
</dict>
</plist>
```