### PR TITLE
Fix inquiry format buttons

### DIFF
--- a/Application/CustomTypeViewController.swift
+++ b/Application/CustomTypeViewController.swift
@@ -64,6 +64,10 @@ class DropSensor: NSView {
         registerForDraggedTypes(acceptableTypes)
     }
     
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        return nil
+    }
+    
     override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
         self.dropDelegate?.enterDrag(sender)
         return .every


### PR DESCRIPTION
This fixes the button actions by allowing clicks to pass through the `DropSensor` view.

Previously, the "Close" button and the others were not clickable.
<img width="501" alt="PixelSnap 2025-12-10 at 22 05 47@2x" src="https://github.com/user-attachments/assets/ede4831b-f685-4112-a90e-0577d47e9b42" />
