### PR TITLE
Fix ShellTask stderr capture in TaskResult

### DIFF
--- a/XPCService/TaskResult.swift
+++ b/XPCService/TaskResult.swift
@@ -91,7 +91,7 @@ class ShellTask {
         }
         
         let data = file.readDataToEndOfFile()
-        let dataErr = file.readDataToEndOfFile()
+        let dataErr = fileErr.readDataToEndOfFile()
         
         task.waitUntilExit()
         


### PR DESCRIPTION
## Summary
- read stderr from the stderr pipe instead of re-reading stdout
- preserve the actual subprocess error output for callers like the XPC render service

## Validation
- built a standalone repro against the buggy source and confirmed output was:
  - exitCode=7
  - stdout=stdout-line
  - stderr=
- built the same repro against this patch and confirmed output was:
  - exitCode=7
  - stdout=stdout-line
  - stderr=stderr-line

## Notes
- this also explains why local Syntax Highlight logs could show a nonzero shell exit with an empty error body