### PR TITLE
Fix brew install command: remove deprecated --no-quarantine

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Head over to the [releases](https://github.com/sbarex/SourceCodeSyntaxHighlight/
 Syntax Highlight can also be installed via [Homebrew](https://brew.sh). If you have not installed Homebrew, follow the simple instructions [here](https://brew.sh/). After that, install the current version of Syntax Highlight with the following command:
 
 ```bash
-brew install --no-quarantine syntax-highlight
+brew install syntax-highlight
 ```
 
 ### Note for the precompiled release


### PR DESCRIPTION
**Summary**
This PR corrects the installation command in README.md to ensure compatibility with current Homebrew standards and fix a syntax error.

**Changes**

Remove Deprecated Option: Removed the --no-quarantine flag.

**Reasoning**
The --no-quarantine option has been deprecated.
Referring to the Homebrew issue below, the flag implementation has been removed.

- Ref: https://github.com/Homebrew/brew/issues/20755